### PR TITLE
Fixing missing scipy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+scipy
 pillow
 numpy
 sklearn


### PR DESCRIPTION
Failed for me with:

```
    Complete output from command /Users/pavel.lishin/Temp/paintingReorganize/venv/bin/python2.7 -c "import setuptools, tokenize;__file__='/Users/pavel.lishin/Temp/paintingReorganize/venv/build/scikit-learn/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /var/folders/gy/9t4cg9d57ql78br71shc63p1zs78jj/T/pip-7iBhec-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/pavel.lishin/Temp/paintingReorganize/venv/bin/../include/site/python2.7:
    Partial import of sklearn during the build process.

Traceback (most recent call last):

  File "/Users/pavel.lishin/Temp/paintingReorganize/venv/build/scikit-learn/setup.py", line 152, in get_scipy_status

    import scipy

ImportError: No module named scipy

Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "/Users/pavel.lishin/Temp/paintingReorganize/venv/build/scikit-learn/setup.py", line 305, in <module>

    setup_package()

  File "/Users/pavel.lishin/Temp/paintingReorganize/venv/build/scikit-learn/setup.py", line 275, in setup_package

    .format(scipy_req_str, instructions))

ImportError: Scientific Python (SciPy) is not installed.

scikit-learn requires SciPy >= 0.9.

Installation instructions are available on the scikit-learn website: http://scikit-learn.org/stable/install.html



----------------------------------------
Cleaning up...
Command /Users/pavel.lishin/Temp/paintingReorganize/venv/bin/python2.7 -c "import setuptools, tokenize;__file__='/Users/pavel.lishin/Temp/paintingReorganize/venv/build/scikit-learn/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /var/folders/gy/9t4cg9d57ql78br71shc63p1zs78jj/T/pip-7iBhec-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/pavel.lishin/Temp/paintingReorganize/venv/bin/../include/site/python2.7 failed with error code 1 in /Users/pavel.lishin/Temp/paintingReorganize/venv/build/scikit-learn
Storing debug log for failure in /Users/pavel.lishin/.pip/pip.log
```

gcc is required for building scipy, so `brew install gcc` may be required.

I'm on OS X Yosemite 10.10.5.